### PR TITLE
Prepare RELEASING.md and CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+This project follows semantic versioning.
+
+Possible log types:
+
+- `[added]` for new features.
+- `[changed]` for changes in existing functionality.
+- `[deprecated]` for once-stable features removed in upcoming releases.
+- `[removed]` for deprecated features removed in this release.
+- `[fixed]` for any bug fixes.
+- `[security]` to invite users to upgrade in case of vulnerabilities.
+
+## [Unreleased]
+
+ - ...
+
+## [2.1.7] - 2016-04-14
+
+ - Initial publication on PyPI
+
+[Unreleased]: https://github.com/lgrahl/threema-msgapi-sdk-python/compare/v2.1.7...HEAD
+[2.1.7]: https://github.com/lgrahl/threema-msgapi-sdk-python/compare/e982c74...v2.1.7

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,35 @@
+# Release process
+
+Signing key: https://path-to-signing-pubkey.asc
+
+Used variables:
+
+    export VERSION={VERSION}
+    export GPG={KEYID}
+
+Update version number in `threema/gateway/__init__.py` and `CHANGELOG.md`:
+
+    $EDITOR threema/gateway/__init__.py CHANGELOG.md
+
+Do a signed commit and signed tag of the release:
+
+    git add setup.py CHANGELOG.md
+    git commit -S${GPG} -m "Release v${VERSION}"
+    git tag -u ${GPG} -m "Release v${VERSION}" v${VERSION}
+
+Build source and binary distributions:
+
+    python3 setup.py sdist
+    python3 setup.py bdist_wheel
+
+Sign files:
+
+    gpg --detach-sign -u ${GPG} -a dist/threema.gateway-${VERSION}.tar.gz
+    gpg --detach-sign -u ${GPG} -a dist/threema.gateway-${VERSION}-py3-none-any.whl
+
+Upload package to PyPI:
+
+    twine3 upload dist/threema.gateway-${VERSION}*
+    git push
+    git push --tags
+


### PR DESCRIPTION
It would be great if this package were available on PyPI (lgrahl/threema-msgapi-sdk-python#11).

I added a changelog file. If you want, you can also add change information for past releases.

The `RELEASING.md` contains instructions for registering and uploading a GPG signed release to PyPI. For more information and recommendations, see https://packaging.python.org/.

Is there anything else I can do to help?
