### PR TITLE
Optional blocking API

### DIFF
--- a/examples/e2e_blocking.py
+++ b/examples/e2e_blocking.py
@@ -1,0 +1,128 @@
+"""
+You can modify and use one of the functions below to test the gateway
+service with your end-to-end account.
+"""
+import logbook
+import logbook.more
+
+from threema.gateway import util, Connection, GatewayError
+from threema.gateway.e2e import TextMessage, ImageMessage, FileMessage
+
+
+def send(connection):
+    """
+    Send a message to a specific Threema ID.
+
+    Note that the public key will be automatically fetched from the
+    Threema servers. It is strongly recommended that you cache
+    public keys to avoid querying the API for each message.
+    """
+    message = TextMessage(
+        connection=connection,
+        to_id='ECHOECHO',
+        text='私はガラスを食べられます。それは私を傷つけません。'
+    )
+    return message.send()
+
+
+def send_cached_key(connection):
+    """
+    Send a message to a specific Threema ID with an already cached
+    public key of that recipient.
+    """
+    message = TextMessage(
+        connection=connection,
+        to_id='ECHOECHO',
+        key='public:4a6a1b34dcef15d43cb74de2fd36091be99fbbaf126d099d47d83d919712c72b',
+        text='私はガラスを食べられます。それは私を傷つけません。'
+    )
+    return message.send()
+
+
+def send_cached_key_file(connection):
+    """
+    Send a message to a specific Threema ID with an already cached
+    public key (stored in a file) of that recipient.
+    """
+    message = TextMessage(
+        connection=connection,
+        to_id='ECHOECHO',
+        key_file='ECHOECHO.txt',
+        text='私はガラスを食べられます。それは私を傷つけません。'
+    )
+    return message.send()
+
+
+def send_image(connection):
+    """
+    Send an image to a specific Threema ID.
+
+    Note that the public key will be automatically fetched from the
+    Threema servers. It is strongly recommended that you cache
+    public keys to avoid querying the API for each message.
+    """
+    message = ImageMessage(
+        connection=connection,
+        to_id='ECHOECHO',
+        image_path='res/threema.jpg'
+    )
+    return message.send()
+
+
+def send_file(connection):
+    """
+    Send a file to a specific Threema ID.
+
+    Note that the public key will be automatically fetched from the
+    Threema servers. It is strongly recommended that you cache
+    public keys to avoid querying the API for each message.
+    """
+    message = FileMessage(
+        connection=connection,
+        to_id='ECHOECHO',
+        file_path='res/some_file.zip'
+    )
+    return message.send()
+
+
+def send_file_with_thumbnail(connection):
+    """
+    Send a file to a specific Threema ID including a thumbnail.
+
+    Note that the public key will be automatically fetched from the
+    Threema servers. It is strongly recommended that you cache
+    public keys to avoid querying the API for each message.
+    """
+    message = FileMessage(
+        connection=connection,
+        to_id='ECHOECHO',
+        file_path='res/some_file.zip',
+        thumbnail_path='res/some_file_thumb.png'
+    )
+    return message.send()
+
+
+def main():
+    connection = Connection(
+        identity='*YOUR_GATEWAY_THREEMA_ID',
+        secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
+        key='private:YOUR_PRIVATE_KEY',
+        blocking=True,
+    )
+    try:
+        with connection:
+            send(connection)
+            send_cached_key(connection)
+            send_cached_key_file(connection)
+            send_image(connection)
+            send_file(connection)
+            send_file_with_thumbnail(connection)
+    except GatewayError as exc:
+        print('Error:', exc)
+
+
+if __name__ == '__main__':
+    util.enable_logging(logbook.WARNING)
+    log_handler = logbook.more.ColorizedStderrHandler()
+    with log_handler.applicationbound():
+        main()

--- a/examples/e2e_blocking.py
+++ b/examples/e2e_blocking.py
@@ -5,8 +5,16 @@ service with your end-to-end account.
 import logbook
 import logbook.more
 
-from threema.gateway import util, Connection, GatewayError
-from threema.gateway.e2e import TextMessage, ImageMessage, FileMessage
+from threema.gateway import (
+    Connection,
+    GatewayError,
+    util,
+)
+from threema.gateway.e2e import (
+    FileMessage,
+    ImageMessage,
+    TextMessage,
+)
 
 
 def send(connection):

--- a/examples/lookup_blocking.py
+++ b/examples/lookup_blocking.py
@@ -11,9 +11,9 @@ from threema.gateway.key import Key
 
 def main():
     connection = Connection(
+        blocking=True,
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
-        blocking=True
     )
     try:
         with connection:

--- a/examples/lookup_blocking.py
+++ b/examples/lookup_blocking.py
@@ -1,0 +1,38 @@
+"""
+You can modify and use one of the lines below to test the lookup
+functionality of the gateway service.
+"""
+import logbook
+import logbook.more
+
+from threema.gateway import util, Connection, GatewayError
+from threema.gateway.key import Key
+
+
+def main():
+    connection = Connection(
+        identity='*YOUR_GATEWAY_THREEMA_ID',
+        secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
+        blocking=True
+    )
+    try:
+        with connection:
+            print(connection.get_credits())
+            print(connection.get_id(phone='41791234567'))
+            hash_ = 'ad398f4d7ebe63c6550a486cc6e07f9baa09bd9d8b3d8cb9d9be106d35a7fdbc'
+            print(connection.get_id(phone_hash=hash_))
+            print(connection.get_id(email='test@threema.ch'))
+            hash_ = '1ea093239cc5f0e1b6ec81b866265b921f26dc4033025410063309f4d1a8ee2c'
+            print(connection.get_id(email_hash=hash_))
+            key = connection.get_public_key('ECHOECHO')
+            print(Key.encode(key))
+            print(connection.get_reception_capabilities('ECHOECHO'))
+    except GatewayError as exc:
+        print('Error:', exc)
+
+
+if __name__ == '__main__':
+    util.enable_logging(logbook.WARNING)
+    log_handler = logbook.more.ColorizedStderrHandler()
+    with log_handler.applicationbound():
+        main()

--- a/examples/lookup_blocking.py
+++ b/examples/lookup_blocking.py
@@ -5,7 +5,11 @@ functionality of the gateway service.
 import logbook
 import logbook.more
 
-from threema.gateway import util, Connection, GatewayError
+from threema.gateway import (
+    Connection,
+    GatewayError,
+    util,
+)
 from threema.gateway.key import Key
 
 

--- a/examples/simple_blocking.py
+++ b/examples/simple_blocking.py
@@ -5,7 +5,11 @@ service with your account.
 import logbook
 import logbook.more
 
-from threema.gateway import util, Connection, GatewayError
+from threema.gateway import (
+    Connection,
+    GatewayError,
+    util,
+)
 from threema.gateway.simple import TextMessage
 
 

--- a/examples/simple_blocking.py
+++ b/examples/simple_blocking.py
@@ -2,20 +2,13 @@
 You can modify and use one of the functions below to test the gateway
 service with your account.
 """
-import asyncio
-
 import logbook
 import logbook.more
 
-from threema.gateway import (
-    Connection,
-    GatewayError,
-    util,
-)
+from threema.gateway import util, Connection, GatewayError
 from threema.gateway.simple import TextMessage
 
 
-@asyncio.coroutine
 def send_via_id(connection):
     """
     Send a message to a specific Threema ID.
@@ -25,10 +18,9 @@ def send_via_id(connection):
         to_id='ECHOECHO',
         text='Hello from the world of Python!'
     )
-    return (yield from message.send())
+    return message.send()
 
 
-@asyncio.coroutine
 def send_via_email(connection):
     """
     Send a message via an email address.
@@ -38,10 +30,9 @@ def send_via_email(connection):
         email='test@threema.ch',
         text='Hello from the world of Python!'
     )
-    return (yield from message.send())
+    return message.send()
 
 
-@asyncio.coroutine
 def send_via_phone(connection):
     """
     Send a message via a phone number.
@@ -51,20 +42,20 @@ def send_via_phone(connection):
         phone='41791234567',
         text='Hello from the world of Python!'
     )
-    return (yield from message.send())
+    return message.send()
 
 
-@asyncio.coroutine
 def main():
     connection = Connection(
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
+        blocking=True,
     )
     try:
         with connection:
-            yield from send_via_id(connection)
-            yield from send_via_email(connection)
-            yield from send_via_phone(connection)
+            send_via_id(connection)
+            send_via_email(connection)
+            send_via_phone(connection)
     except GatewayError as exc:
         print('Error:', exc)
 
@@ -73,6 +64,4 @@ if __name__ == '__main__':
     util.enable_logging(logbook.WARNING)
     log_handler = logbook.more.ColorizedStderrHandler()
     with log_handler.applicationbound():
-        loop = asyncio.get_event_loop()
-        loop.run_until_complete(main())
-        loop.close()
+        main()

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         'libnacl>=1.5,<2',
         'click>=6.7,<7',  # doesn't seem to follow semantic versioning
         'aiohttp>=1.3.5,<2',
+        'wrapt>=1.10.10,<2',
     ],
     tests_require=tests_require,
     extras_require={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -423,6 +423,28 @@ def connection(request, api_server, mock_url):
 
 
 @pytest.fixture(scope='module')
+def connection_blocking(request, api_server, mock_url):
+    # Note: We're not doing anything with the server but obviously the
+    # server needs to be started to be able to connect
+    connection_ = threema.gateway.Connection(
+        identity=pytest.msgapi.id,
+        secret=pytest.msgapi.secret,
+        key=pytest.msgapi.private,
+        blocking=True,
+    )
+
+    # Patch URLs
+    connection_.urls = {key: value.replace(pytest.msgapi.base_url, mock_url)
+                        for key, value in connection_.urls.items()}
+
+    def fin():
+        connection_.close()
+
+    request.addfinalizer(fin)
+    return connection_
+
+
+@pytest.fixture(scope='module')
 def invalid_connection(connection):
     invalid_connection_ = copy.copy(connection)
     invalid_connection_.id = pytest.msgapi.noexist_id

--- a/tests/test_blocking_api.py
+++ b/tests/test_blocking_api.py
@@ -1,0 +1,42 @@
+from threema.gateway import e2e, simple
+
+
+def test_lookup_id_by_phone(connection_blocking):
+    identity = connection_blocking.get_id(phone='44123456789')
+    assert identity == 'ECHOECHO'
+
+
+def test_lookup_id_by_phone_hash(connection_blocking):
+    hash_ = '98b05f6eda7a878f6f016bdcdc9db6eb61a6b190e814ff787142115af144214c'
+    identity = connection_blocking.get_id(phone_hash=hash_)
+    assert identity == 'ECHOECHO'
+
+
+def test_lookup_public_key(connection_blocking, server):
+    key = connection_blocking.get_public_key('ECHOECHO')
+    assert key.hex_pk() == server.echoecho_key
+
+
+def test_lookup_reception_capabilities(connection_blocking):
+    capabilities = connection_blocking.get_reception_capabilities('ECHOECHO')
+    assert len(capabilities) == 4
+
+
+def test_send_e2e_text_message(connection_blocking):
+    message = e2e.TextMessage(
+        connection=connection_blocking,
+        to_id='ECHOECHO',
+        text='Hello. This works quite nicely!',
+    )
+    id_ = message.send()
+    assert id_ == '1' * 16
+
+
+def test_send_simple_text_message(connection_blocking):
+    message = simple.TextMessage(
+        connection=connection_blocking,
+        to_id='ECHOECHO',
+        text='Hello. This works quite nicely!',
+    )
+    id_ = message.send()
+    assert id_ == '0' * 16

--- a/tests/test_blocking_api.py
+++ b/tests/test_blocking_api.py
@@ -1,4 +1,7 @@
-from threema.gateway import e2e, simple
+from threema.gateway import (
+    e2e,
+    simple,
+)
 
 
 def test_lookup_id_by_phone(connection_blocking):

--- a/threema/gateway/__init__.py
+++ b/threema/gateway/__init__.py
@@ -30,7 +30,7 @@ from .exception import *  # noqa
 
 __author__ = 'Lennart Grahl <lennart.grahl@threema.ch>'
 __status__ = 'Production'
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 feature_level = 3
 
 __all__ = tuple(itertools.chain(

--- a/threema/gateway/_gateway.py
+++ b/threema/gateway/_gateway.py
@@ -20,6 +20,7 @@ from .exception import (
 from .key import Key
 from .util import (
     aio_run_decorator,
+    aio_run_proxy_decorator,
     async_lru_cache,
     raise_server_error,
     AioRunMixin,
@@ -43,6 +44,7 @@ class ReceptionCapability(enum.Enum):
     file = 'file'
 
 
+@aio_run_proxy_decorator
 class Connection(AioRunMixin):
     """
     Container for the sender's Threema ID and the Threema Gateway
@@ -67,6 +69,16 @@ class Connection(AioRunMixin):
           TLS certificate of the Threema Gateway Server by a
           fingerprint. (Recommended)
     """
+    async_functions = {
+        'get_public_key',
+        'get_id',
+        'get_reception_capabilities',
+        'get_credits',
+        'send_simple',
+        'send_e2e',
+        'upload',
+        'download',
+    }
     fingerprint = binascii.unhexlify(b'b07be4814ba2b006be7910a0a695370f')
     urls = {
         'get_public_key': 'https://msgapi.threema.ch/pubkeys/{}',
@@ -81,16 +93,6 @@ class Connection(AioRunMixin):
         'upload_blob': 'https://msgapi.threema.ch/upload_blob',
         'download_blob': 'https://msgapi.threema.ch/blobs/{}'
     }
-    async_functions = [
-        'get_public_key',
-        'get_id',
-        'get_reception_capabilities',
-        'get_credits',
-        'send_simple',
-        'send_e2e',
-        'upload',
-        'download',
-    ]
 
     def __init__(
             self, identity, secret,

--- a/threema/gateway/_gateway.py
+++ b/threema/gateway/_gateway.py
@@ -54,6 +54,11 @@ class Connection(AioRunMixin):
     :func:`~Connection.close` after you are done querying the Threema
     Gateway Service API.
 
+    The connection can work both in non-blocking (through asyncio) and blocking
+    mode. If you want to use the API in a blocking way (which implicitly starts
+    an event loop to process the requests), then instantiate this class with
+    ``blocking=True``.
+
     Arguments:
         - `id`: Threema ID of the sender.
         - `secret`: Threema Gateway secret.
@@ -67,6 +72,8 @@ class Connection(AioRunMixin):
         - `verify_fingerprint`: Set to `True` if you want to verify the
           TLS certificate of the Threema Gateway Server by a
           fingerprint. (Recommended)
+        - `blocking`: Whether to use a blocking API, without the need for an
+          explicit event loop.
     """
     async_functions = {
         'get_public_key',

--- a/threema/gateway/_gateway.py
+++ b/threema/gateway/_gateway.py
@@ -19,11 +19,10 @@ from .exception import (
 )
 from .key import Key
 from .util import (
-    aio_run_decorator,
+    AioRunMixin,
     aio_run_proxy_decorator,
     async_lru_cache,
     raise_server_error,
-    AioRunMixin,
 )
 
 __all__ = (

--- a/threema/gateway/bin/gateway_client.py
+++ b/threema/gateway/bin/gateway_client.py
@@ -6,7 +6,6 @@ import binascii
 import os
 import re
 
-
 import aiohttp
 import click
 import logbook

--- a/threema/gateway/bin/gateway_client.py
+++ b/threema/gateway/bin/gateway_client.py
@@ -6,6 +6,7 @@ import binascii
 import os
 import re
 
+
 import aiohttp
 import click
 import logbook
@@ -23,6 +24,7 @@ from threema.gateway.key import (
     HMAC,
     Key,
 )
+from threema.gateway.util import AioRunMixin
 
 _logging_handler = None
 _logging_levels = {
@@ -45,8 +47,9 @@ if _test_port is not None:
                 'The Threema Gateway Server will not be contacted!'), err=True)
 
 
-class _MockConnection:
+class _MockConnection(AioRunMixin):
     def __init__(self, private_key, public_key, identity=None):
+        super().__init__(blocking=False)
         self.key = private_key
         self._public_key = public_key
         self.id = identity
@@ -463,9 +466,9 @@ def main():
         cli()
     except aiohttp.FingerprintMismatch:
         error = 'Fingerprints did not match!'
-    except Exception as exc:
-        error = str(exc)
-        exc = exc
+    except Exception as exc_:
+        error = str(exc_)
+        exc = exc_
     else:
         error = None
 

--- a/threema/gateway/e2e.py
+++ b/threema/gateway/e2e.py
@@ -22,10 +22,7 @@ import libnacl.secret
 from aiohttp import web
 from aiohttp.web_urldispatcher import UrlDispatcher
 
-from . import (
-    ReceptionCapability,
-    util,
-)
+from . import ReceptionCapability
 from .exception import (
     CallbackError,
     DirectionError,
@@ -35,11 +32,11 @@ from .exception import (
 )
 from .key import Key
 from .util import (
-    aio_run_proxy_decorator,
-    randint,
     AioRunMixin,
     ViewIOReader,
     ViewIOWriter,
+    aio_run_proxy_decorator,
+    randint,
 )
 
 __all__ = (

--- a/threema/gateway/e2e.py
+++ b/threema/gateway/e2e.py
@@ -292,6 +292,9 @@ class Message(AioRunMixin, metaclass=abc.ABCMeta):
     """
     A message class all end-to-end mode messages are derived from.
 
+    If the connection passed to the constructor is in blocking mode, then all
+    methods on this class will be blocking too.
+
     Attributes:
         - `connection`: An instance of a connection.
         - `type_`: The message type.
@@ -680,7 +683,8 @@ class DeliveryReceipt(Message):
     Each delivery receipt message confirms the receipt of one
     or multiple regular text messages.
 
-    .. note:: Sending delivery receipts is not officially supported.
+    If the connection passed to the constructor is in blocking mode, then all
+    methods on this class will be blocking too.
 
     Arguments:
         - `payload`: The remaining byte sequence of the message.
@@ -770,6 +774,9 @@ class TextMessage(Message):
     """
     A text message.
 
+    If the connection passed to the constructor is in blocking mode, then all
+    methods on this class will be blocking too.
+
     Arguments for a new message:
         - `connection`: An instance of a connection.
         - `id`: Threema ID of the recipient.
@@ -835,6 +842,9 @@ class TextMessage(Message):
 class ImageMessage(Message):
     """
     An image message.
+
+    If the connection passed to the constructor is in blocking mode, then all
+    methods on this class will be blocking too.
 
     Arguments for a new message:
         - `connection`: An instance of a connection.
@@ -972,6 +982,9 @@ class ImageMessage(Message):
 class FileMessage(Message):
     """
     A file message including a thumbnail.
+
+    If the connection passed to the constructor is in blocking mode, then all
+    methods on this class will be blocking too.
 
     Arguments for a new message:
         - `connection`: An instance of a connection.

--- a/threema/gateway/simple.py
+++ b/threema/gateway/simple.py
@@ -5,7 +5,10 @@ import abc
 import asyncio
 
 from .exception import MessageError
-from .util import aio_run_proxy_decorator, AioRunMixin
+from .util import (
+    AioRunMixin,
+    aio_run_proxy_decorator,
+)
 
 __all__ = (
     'Message',

--- a/threema/gateway/simple.py
+++ b/threema/gateway/simple.py
@@ -20,6 +20,9 @@ class Message(AioRunMixin, metaclass=abc.ABCMeta):
     """
     A message class all simple mode messages are derived from.
 
+    If the connection passed to the constructor is in blocking mode, then all
+    methods on this class will be blocking too.
+
     Attributes:
         - `connection`: An instance of a connection.
         - `to_id`: Threema ID of the recipient.
@@ -45,6 +48,9 @@ class Message(AioRunMixin, metaclass=abc.ABCMeta):
 class TextMessage(Message):
     """
     Create and send a text message to a recipient.
+
+    If the connection passed to the constructor is in blocking mode, then all
+    methods on this class will be blocking too.
 
     Arguments / Attributes:
         - `connection`: An instance of a connection.

--- a/threema/gateway/util.py
+++ b/threema/gateway/util.py
@@ -4,6 +4,7 @@ Utility functions.
 import asyncio
 import collections
 import functools
+import inspect
 import io
 import logging
 import os
@@ -14,6 +15,7 @@ import logbook.compat
 import logbook.more
 # noinspection PyPackageRequirements
 import lru
+import wrapt
 
 from .key import Key
 
@@ -29,6 +31,7 @@ __all__ = (
     'async_lru_cache',
     'aio_run',
     'aio_run_decorator',
+    'aio_run_proxy_decorator',
     'AioRunMixin',
 )
 
@@ -521,26 +524,91 @@ def aio_run_decorator(loop=None, close_after_complete=False):
             func = asyncio.coroutine(func)
 
         def _wrapper(*args, **kwargs):
-            return aio_run(func(*args, **kwargs))
+            return aio_run(
+                func(*args, **kwargs),
+                loop=loop,
+                close_after_complete=close_after_complete,
+            )
         return functools.update_wrapper(_wrapper, func)
     return _decorator
 
 
-class AioRunMixin:
-    async_functions = None
+def aio_run_proxy_decorator(cls):
+    """
+    Proxy a publicly accessible class and run all methods marked as
+    async inside it (using the class attribute `async_functions`) with
+    an event loop to make it appear as a traditional blocking method.
 
-    def __new__(cls, *args, **kwargs):
-        # Ensure the class has added a class-level iterable of async functions
+    Arguments:
+        - `cls`: A class to be wrapped. The class must inherit
+          :class:`AioRunMixin`. The class and all base classes must
+          supply a class attribute `async_functions` which is an
+          iterable of method names that should appear as traditional
+          blocking functions from the outside.
+
+    Returns a class factory.
+
+    .. note:: The `unwrap` property of the resulting instance can be
+              used to get the original instance.
+    """
+    # Ensure each base class has added a class-level iterable of async functions
+    async_functions = set()
+    for base_class in inspect.getmro(cls)[:-1]:
         try:
-            iter(cls.async_functions)
+            async_functions.update(base_class.__dict__.get('async_functions', None))
         except TypeError:
-            message = "Cannot instantiate class {} with missing 'async_functions' iterable"
-            raise ValueError(message.format(cls.__name__))
+            message = "Class {} is missing 'async_functions' iterable"
+            raise ValueError(message.format(base_class.__name__))
 
-        return super().__new__(cls)
+    def _decorator(*args, **kwargs):
+        # Create instance
+        instance = cls(*args, **kwargs)
+
+        # Sanity-check
+        if not isinstance(instance, AioRunMixin):
+            raise TypeError("Class {} did not inherit 'AioRunMixin'".format(cls.__name__))
+
+        # Wrap with proxy (if required)
+        if instance.blocking:
+            class _AioRunProxy(wrapt.ObjectProxy):
+                @property
+                def unwrap(self):
+                    """
+                    Get the wrapped instance.
+                    """
+                    return self.__wrapped__
+
+            # Wrap all async functions with `aio_run`
+            for name in async_functions:
+                def _method(instance_, name_, *args_, **kwargs_):
+                    method = aio_run_decorator()(getattr(instance_, name_))
+                    return method(*args_, **kwargs_)
+
+                _method = functools.partial(_method, instance, name)
+                setattr(_AioRunProxy, name, _method)
+
+            return _AioRunProxy(instance)
+        else:
+            return instance
+
+    return _decorator
+
+
+class AioRunMixin:
+    """
+    Must be inherited when using :func:`aio_run_proxy_decorator`.
+
+    Arguments:
+        - `blocking`: Switch to turn the blocking API on or off.
+    """
+    async_functions = set()
 
     def __init__(self, blocking=False):
-        # Blocking? Wrap all public coroutines with `aio_run`
-        if blocking:
-            for method in self.async_functions:
-                setattr(self, method, aio_run_decorator()(getattr(self, method)))
+        self.blocking = blocking
+
+    @property
+    def unwrap(self):
+        """
+        Get the wrapped instance.
+        """
+        return self

--- a/threema/gateway/util.py
+++ b/threema/gateway/util.py
@@ -8,6 +8,7 @@ import inspect
 import io
 import logging
 import os
+from typing import Set  # noqa
 
 import libnacl
 import logbook
@@ -608,7 +609,7 @@ class AioRunMixin:
     Arguments:
         - `blocking`: Switch to turn the blocking API on or off.
     """
-    async_functions = set()
+    async_functions = set()  # type: Set[str]
 
     def __init__(self, blocking=False):
         self.blocking = blocking


### PR DESCRIPTION
These changes add a `blocking` parameter to the `Connection` class. If set to `True`, all API functions will be called in a blocking manner (and thus do not require an asyncio event loop for execution).

To do:
- [x] Add tests
- [x] Update docstrings