### PR TITLE
setup.py: Detect packages automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,10 @@ import ast
 import os
 import sys
 
-from setuptools import setup
+from setuptools import (
+    find_packages,
+    setup,
+)
 
 
 def get_version():
@@ -48,7 +51,7 @@ tests_require = [
 setup(
     name='threema.gateway',
     version=get_version(),
-    packages=['threema', 'threema.gateway'],
+    packages=find_packages(),
     namespace_packages=['threema'],
     install_requires=[
         'py_lru_cache>=0.1.4,<0.2',


### PR DESCRIPTION
This should fix the missing `threema.gateway.bin` package in the published distribution, which is broken.

```
$ threema-gateway version
Traceback (most recent call last):
  File "/.virtualenvs/tmp/bin/threema-gateway", line 11, in <module>
    load_entry_point('threema.gateway==3.0.2', 'console_scripts', 'threema-gateway')()
  File "/.virtualenvs/tmp/lib/python3.6/site-packages/pkg_resources/__init__.py", line 560, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/.virtualenvs/tmp/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2648, in load_entry_point
    return ep.load()
  File "/.virtualenvs/tmp/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2302, in load
    return self.resolve()
  File "/.virtualenvs/tmp/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2308, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
ModuleNotFoundError: No module named 'threema.gateway.bin'
```

@lgrahl could you create a release with a fix soon?