### PR TITLE
gateway_client.py: fix aiohttp exception handling

### DIFF
--- a/threema/gateway/bin/gateway_client.py
+++ b/threema/gateway/bin/gateway_client.py
@@ -11,6 +11,8 @@ import click
 import logbook
 import logbook.more
 
+from aiohttp.client_exceptions import ServerFingerprintMismatch
+
 from threema.gateway import __version__ as _version
 from threema.gateway import (
     Connection,
@@ -463,11 +465,12 @@ def main():
     exc = None
     try:
         cli()
-    except aiohttp.FingerprintMismatch:
-        error = 'Fingerprints did not match!'
     except Exception as exc_:
-        error = str(exc_)
-        exc = exc_
+        if isinstance(exc_, ServerFingerprintMismatch):
+            error = 'Fingerprints did not match!'
+        else:
+            error = str(exc_)
+            exc = exc_
     else:
         error = None
 


### PR DESCRIPTION
I've been trying to update the FreeBSD port of the SDK to 3.0.5 and ran into some issues with exceptions in newer versions of ``aiohttp``.  I just noticed your [aiohttp-2.0 branch](https://github.com/lgrahl/threema-msgapi-sdk-python/tree/aiohttp-2.0) though, so this patch may already be "overtaken by events".

In any case: this may not be the best way to do it.  I wonder why ``FingerprintMismatch`` needs to be caught separately at all.  Why don't we just treat it like any other exception?