### PR TITLE
Add compatibility with aiohttp 2.3.1

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,7 +386,7 @@ def api_server(request, event_loop, api_server_port, server):
     server_ = event_loop.run_until_complete(coroutine)
 
     def fin():
-        event_loop.run_until_complete(handler.finish_connections(1.0))
+        event_loop.run_until_complete(handler.shutdown(1.0))
         server_.close()
         event_loop.run_until_complete(server_.wait_closed())
         event_loop.run_until_complete(app.cleanup())

--- a/threema/gateway/e2e.py
+++ b/threema/gateway/e2e.py
@@ -190,7 +190,7 @@ class AbstractCallback(metaclass=abc.ABCMeta):
     def close(self, timeout=10.0):
         # Stop handler and application
         yield from self.application.shutdown()
-        yield from self.handler.finish_connections(timeout=timeout)
+        yield from self.handler.shutdown(timeout=timeout)
         yield from self.application.cleanup()
 
     @asyncio.coroutine


### PR DESCRIPTION
The `finish_connections` method has been deprecated (ref: aio-libs/aiohttp#2006) and was replaced
with `shutdown`.  No functional change.

```
============================= test session starts ==============================
platform freebsd11 -- Python 3.6.3, pytest-3.2.3, py-1.4.34, pluggy-0.4.0
Using event loop: asyncio
rootdir: /wrkdirs/usr/ports/devel/py3-threema-msgapi/work/threema-msgapi-sdk-python-3.0.6, inifile:
plugins: asyncio-0.8.0
collected 104 items

tests/test_api.py ...................................................................
tests/test_base.py ...
tests/test_blocking_api.py ......
tests/test_callback.py ......
tests/test_cli.py ......................

========================= 104 passed in 23.54 seconds ==========================
```