### PR TITLE
Maintenance Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ gen
 
 # Vim
 *.swp
+
+# VS Code
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ gen
 
 # VS Code
 .vscode/
+
+# MyPy Cache
+.mypy_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,15 @@ before_cache:
 language: python
 matrix:
   include:
-  - python: "3.4"
-    env: EVENT_LOOP=asyncio
   - python: "3.5"
     env: EVENT_LOOP=asyncio
-  - python: "3.5"
-    env: EVENT_LOOP=uvloop
-    before_script: "pip install .[uvloop]"
   - python: "3.6"
     env: EVENT_LOOP=asyncio
-  - python: "3.6"
+  - python: "3.7"
+    env: EVENT_LOOP=asyncio
+  - python: "3.8"
+    env: EVENT_LOOP=asyncio
+  - python: "3.8"
     env: EVENT_LOOP=uvloop
     before_script: "pip install .[uvloop]"
 
@@ -39,11 +38,8 @@ install:
 
 # Run flake8, isort, check docs & tests
 script:
-  - >
-    if [[ "$TRAVIS_PYTHON_VERSION" != "pypy3" ]]; then
-      flake8 . || travis_terminate 1;
-      isort -rc -c . || (isort -rc -df . && return 1) || travis_terminate 1;
-    fi
+  - flake8 .
+  - isort -rc -c . || (isort -rc -df . && return 1)
   - python setup.py checkdocs
   - py.test --cov-config .coveragerc --cov=threema.gateway --loop=$EVENT_LOOP
   - mypy .

--- a/setup.py
+++ b/setup.py
@@ -38,14 +38,14 @@ if py_version < (3, 4):
 # Note: These are just tools that aren't required, so a version range
 #       is not necessary here.
 tests_require = [
-    'pytest>=3.1.3',
-    'pytest-asyncio>=0.6.0',
-    'pytest-cov>=2.5.1',
-    'flake8>=3.3.0',
-    'isort>=4.2.15',
+    'pytest>=3.1.3,<4',
+    'pytest-asyncio>=0.6.0,<0.10',
+    'pytest-cov>=2.5.1,<3',
+    'flake8==3.7.9',
+    'isort==4.3.21',
     'collective.checkdocs>=0.2',
     'Pygments>=2.2.0',  # required by checkdocs
-    'mypy>=0.521',
+    'mypy==0.770',
 ]
 
 setup(
@@ -58,7 +58,7 @@ setup(
         'logbook>=1.1.0,<2',
         'libnacl>=1.5.2,<2',
         'click>=6.7,<7',  # doesn't seem to follow semantic versioning
-        'aiohttp>=2.2.5,<3',
+        'aiohttp>=2.3.10,<3',
         'wrapt>=1.10.10,<2',
     ],
     tests_require=tests_require,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,10 @@ import threema.gateway
 from threema.gateway import e2e
 from threema.gateway.key import Key
 
+# Turn off deprecation warnings for now
+# TODO: Port code to async/await
+os.environ['PYTHONWARNINGS'] = 'ignore'
+
 _res_path = os.path.normpath(os.path.join(
     os.path.abspath(__file__), os.pardir, 'res'))
 
@@ -85,7 +89,7 @@ class Server:
     @asyncio.coroutine
     def pubkeys(self, request):
         key = request.match_info['key']
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
         elif len(key) != 8:
@@ -99,7 +103,7 @@ class Server:
     @asyncio.coroutine
     def lookup_phone(self, request):
         phone = request.match_info['phone']
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
         elif not phone.isdigit():
@@ -111,7 +115,7 @@ class Server:
     @asyncio.coroutine
     def lookup_phone_hash(self, request):
         phone_hash = request.match_info['phone_hash']
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         hash_ = '98b05f6eda7a878f6f016bdcdc9db6eb61a6b190e814ff787142115af144214c'
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
@@ -127,7 +131,7 @@ class Server:
     @asyncio.coroutine
     def lookup_email(self, request):
         email = request.match_info['email']
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
         elif email == 'echoecho@example.com':
@@ -137,7 +141,7 @@ class Server:
     @asyncio.coroutine
     def lookup_email_hash(self, request):
         email_hash = request.match_info['email_hash']
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         hash_ = '45a13d422b40f81936a9987245d3f6d9064c90607273af4f578246b4484669e2'
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
@@ -153,7 +157,7 @@ class Server:
     @asyncio.coroutine
     def capabilities(self, request):
         id_ = request.match_info['id']
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
         elif id_ == 'ECHOECHO':
@@ -164,7 +168,7 @@ class Server:
 
     @asyncio.coroutine
     def credits(self, request):
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
         return web.Response(body=b'100')
@@ -227,7 +231,7 @@ class Server:
             data = (yield from request.post())
 
             # Check API identity
-            api_identity = (request.GET['from'], request.GET['secret'])
+            api_identity = (request.query['from'], request.query['secret'])
             if api_identity not in pytest.msgapi.api_identities:
                 return web.Response(status=401)
         except KeyError:
@@ -244,7 +248,7 @@ class Server:
         blob_id = hashlib.md5(blob).hexdigest()
 
         # Process
-        if request.GET['from'] == pytest.msgapi.nocredit_id:
+        if request.query['from'] == pytest.msgapi.nocredit_id:
             return web.Response(status=402)
         elif len(blob) == 0:
             return web.Response(status=400)
@@ -261,7 +265,7 @@ class Server:
         blob_id = request.match_info['blob_id']
 
         # Check API identity
-        from_, secret = request.GET['from'], request.GET['secret']
+        from_, secret = request.query['from'], request.query['secret']
         if (from_, secret) not in pytest.msgapi.api_identities:
             return web.Response(status=401)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,11 +2,9 @@ import subprocess
 
 import pytest
 
+from threema.gateway import ReceptionCapability
 from threema.gateway import __version__ as _version
-from threema.gateway import (
-    ReceptionCapability,
-    feature_level,
-)
+from threema.gateway import feature_level
 from threema.gateway.key import Key
 
 

--- a/threema/gateway/__init__.py
+++ b/threema/gateway/__init__.py
@@ -23,6 +23,8 @@ The mode that you can use depends on the way your account was set up.
 """
 import itertools
 
+from . import _gateway
+from . import exception as _exception
 from ._gateway import *  # noqa
 from .exception import *  # noqa
 
@@ -34,6 +36,6 @@ feature_level = 3
 __all__ = tuple(itertools.chain(
     ('feature_level',),
     ('bin', 'simple', 'e2e', 'key', 'util'),
-    _gateway.__all__,  # noqa
-    exception.__all__,  # noqa
+    _gateway.__all__,
+    _exception.__all__,
 ))

--- a/threema/gateway/__init__.py
+++ b/threema/gateway/__init__.py
@@ -23,9 +23,7 @@ The mode that you can use depends on the way your account was set up.
 """
 import itertools
 
-# noinspection PyUnresolvedReferences
 from ._gateway import *  # noqa
-# noinspection PyUnresolvedReferences
 from .exception import *  # noqa
 
 __author__ = 'Lennart Grahl <lennart.grahl@gmail.com>'

--- a/threema/gateway/_gateway.py
+++ b/threema/gateway/_gateway.py
@@ -90,7 +90,7 @@ class Connection(AioRunMixin):
         'download',
     }
     fingerprint = binascii.unhexlify(
-        b'a6840a28041a1c43d90c21122ea324272f5c90c82dd64f52701f3a8f1a2b395b')
+        b'42b1038e72f00c8c4dad78a3ebdc6d7a50c5ef288da9019b9171e4d675c08a17')
     urls = {
         'get_public_key': 'https://msgapi.threema.ch/pubkeys/{}',
         'get_id_by_phone': 'https://msgapi.threema.ch/lookup/phone/{}',

--- a/threema/gateway/bin/callback_server.py
+++ b/threema/gateway/bin/callback_server.py
@@ -8,11 +8,9 @@ import click
 import logbook
 import logbook.more
 
+from threema.gateway import Connection
 from threema.gateway import __version__ as _version
-from threema.gateway import (
-    Connection,
-    util,
-)
+from threema.gateway import util
 from threema.gateway.e2e import AbstractCallback
 from threema.gateway.key import Key
 

--- a/threema/gateway/bin/gateway_client.py
+++ b/threema/gateway/bin/gateway_client.py
@@ -11,9 +11,9 @@ import click
 import logbook
 import logbook.more
 
+from threema.gateway import Connection
 from threema.gateway import __version__ as _version
 from threema.gateway import (
-    Connection,
     e2e,
     feature_level,
     simple,

--- a/threema/gateway/e2e.py
+++ b/threema/gateway/e2e.py
@@ -955,7 +955,7 @@ class ImageMessage(Message):
 
         # Pack blob id, image length and image nonce
         try:
-            data = struct.pack(self._formatter, blob_id, len(image_data), image_nonce)
+            data = struct.pack(self._formatter, blob_id, len(self.image), image_nonce)
         except struct.error as exc:
             raise MessageError('Could not pack blob id, length and nonce') from exc
 

--- a/threema/gateway/exception.py
+++ b/threema/gateway/exception.py
@@ -45,7 +45,7 @@ class CallbackError(GatewayError):
         self.reason = reason
 
     def __str__(self):
-        return '[{]}] {]'.format(self.status, self.reason)
+        return '[{}] {}'.format(self.status, self.reason)
 
 
 class GatewayServerError(GatewayError):


### PR DESCRIPTION
- Fix a couple of deprecation warnings
- Bump a few dependencies
- Fix slightly off length calculation for image messages (had the encryption overhead previously but was just used for display purposes in the apps)
- Update the certificate fingerprint of `msgapi.threema.ch`