### PR TITLE
Remove hard-coded fingerprint

### DIFF
--- a/examples/e2e.py
+++ b/examples/e2e.py
@@ -136,7 +136,6 @@ async def main():
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
         key='private:YOUR_PRIVATE_KEY',
-        verify_fingerprint=True,
     )
     try:
         async with connection:

--- a/examples/e2e_blocking.py
+++ b/examples/e2e_blocking.py
@@ -134,7 +134,6 @@ def main():
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
         key='private:YOUR_PRIVATE_KEY',
-        verify_fingerprint=True,
         blocking=True,
     )
     try:

--- a/examples/lookup.py
+++ b/examples/lookup.py
@@ -19,7 +19,6 @@ async def main():
     connection = Connection(
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
-        verify_fingerprint=True,
     )
     try:
         async with connection:

--- a/examples/lookup_blocking.py
+++ b/examples/lookup_blocking.py
@@ -17,7 +17,6 @@ def main():
     connection = Connection(
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
-        verify_fingerprint=True,
         blocking=True,
     )
     try:

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -55,7 +55,6 @@ async def main():
     connection = Connection(
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
-        verify_fingerprint=True,
     )
     try:
         async with connection:

--- a/examples/simple_blocking.py
+++ b/examples/simple_blocking.py
@@ -53,7 +53,6 @@ def main():
     connection = Connection(
         identity='*YOUR_GATEWAY_THREEMA_ID',
         secret='YOUR_GATEWAY_THREEMA_ID_SECRET',
-        verify_fingerprint=True,
         blocking=True,
     )
     try:

--- a/threema/gateway/bin/gateway_client.py
+++ b/threema/gateway/bin/gateway_client.py
@@ -5,7 +5,6 @@ import binascii
 import os
 import re
 
-import aiohttp
 import click
 import logbook
 import logbook.more
@@ -60,11 +59,8 @@ class _MockConnection(AioRunMixin):
 @click.option('-v', '--verbosity', type=click.IntRange(0, len(_logging_levels)),
               default=0, help="Logging verbosity.")
 @click.option('-c', '--colored', is_flag=True, help='Colourise logging output.')
-@click.option('-vf', '--verify-fingerprint', is_flag=True,
-              help='Verify the certificate fingerprint.')
-@click.option('--fingerprint', type=str, help='A hex-encoded fingerprint.')
 @click.pass_context
-def cli(ctx, verbosity, colored, verify_fingerprint, fingerprint):
+def cli(ctx, verbosity, colored):
     """
     Command Line Interface. Use --help for details.
     """
@@ -84,15 +80,8 @@ def cli(ctx, verbosity, colored, verify_fingerprint, fingerprint):
         global _logging_handler
         _logging_handler = handler
 
-    # Fingerprint
-    if fingerprint is not None:
-        fingerprint = binascii.unhexlify(fingerprint)
-
     # Store on context
-    ctx.obj = {
-        'verify_fingerprint': verify_fingerprint,
-        'fingerprint': fingerprint
-    }
+    ctx.obj = {}
 
 
 @cli.command(short_help='Show version information.', help="""
@@ -516,8 +505,6 @@ def main():
     exc = None
     try:
         cli()
-    except aiohttp.client_exceptions.ServerFingerprintMismatch:
-        error = 'Fingerprints did not match!'
     except Exception as exc_:
         error = str(exc_)
         exc = exc_


### PR DESCRIPTION
The fingerprint will change from time to time and hard-coding it in this library we cannot forcibly deploy (unlike e.g. the Threema apps) is a surprising footgun since your services may suddenly fail (when Threema changes the fingerprint). As pointed out in #17, hard-coding the fingerprint (over the public key) is also undesirable. Furthermore, we want users to use their custom `aiohttp.ClientSession` instance. Therefore, we have decided to remove it. If you want to retain this feature, all you have to do is provide your own `aiohttp.ClientSession` in the following way:

```python
Connection(session=aiohttp.ClientSession(
    connector=aiohttp.TCPConnector(ssl=<fingerprint>)))
```

See the aiohttp docs for details.

Closes #17
Resolves #54 
Resolves #13 (by providing your own `SSLContext`)