### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/test-manual.yml
+++ b/.github/workflows/test-manual.yml
@@ -32,7 +32,7 @@ jobs:
           flake8 .
       - name: Lint with isort
         run: |
-          isort -rc -c . || (isort -rc -df . && return 1)
+          isort -c . || (isort -rc -df . && return 1)
       - name: Lint with checkdocs
         run: |
           python setup.py checkdocs

--- a/.github/workflows/test-manual.yml
+++ b/.github/workflows/test-manual.yml
@@ -1,0 +1,44 @@
+name: Manual Test
+
+on: [workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.9", "3.8", "3.7"]
+        event-loop: [asyncio, uvloop]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get install libsodium23
+          python -m pip install -U pip setuptools
+      - name: Install threema.gateway
+        run: |
+          python -m pip install .[dev]
+      - name: Install uvloop for threema.gateway
+        if: ${{ matrix.event-loop == 'uvloop' }}
+        run: |
+          python -m pip install .[uvloop]
+      - name: Lint with flake8
+        run: |
+          flake8 .
+      - name: Lint with isort
+        run: |
+          isort -rc -c . || (isort -rc -df . && return 1)
+      - name: Lint with checkdocs
+        run: |
+          python setup.py checkdocs
+      - name: Lint with mypy
+        run: |
+          mypy setup.py tests examples threema
+      - name: Test with pytest
+        run: |
+          py.test --loop=${{ matrix.event-loop }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10, 3.9, 3.8, 3.7]
+        python-version: ["3.10", "3.9", "3.8", "3.7"]
         event-loop: [asyncio, uvloop]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           flake8 .
       - name: Lint with isort
         run: |
-          isort -rc -c . || (isort -rc -df . && return 1)
+          isort -c . || (isort -rc -df . && return 1)
       - name: Lint with checkdocs
         run: |
           python setup.py checkdocs

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -57,8 +58,6 @@ docs/_build/
 
 # PyBuilder
 target/
-### Example user template template
-### Example user template
 
 # IntelliJ project files
 .idea

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,15 +1,16 @@
 Changelog
 *********
 
-.. `6.0.0`_ (TBD)
-.. ---------------------
+`6.0.0`_ (TBD)
+---------------------
 
-.. General:
+General:
 
-.. - Add support for Python 3.10
-.. - Drop support for Python versions below 3.7
-.. - Major dependencies bump to increase compatibility with other packages
-.. - Updated all tests to work with the newest dependencies
+- Add support for Python 3.10
+- Drop support for Python versions below 3.7
+- Major dependencies bump to increase compatibility with other packages
+- Updated all tests to work with the newest dependencies
+- Changed click syntax to conform with new standard behaviour
 
 
 `5.0.0`_ (2021-05-17)
@@ -77,6 +78,7 @@ Server:
 
 - Initial publication on PyPI
 
+.. _6.0.0: https://github.com/lgrahl/threema-msgapi-sdk-python/compare/v5.0.0...v6.0.0
 .. _5.0.0: https://github.com/lgrahl/threema-msgapi-sdk-python/compare/v4.0.0...v5.0.0
 .. _4.0.0: https://github.com/lgrahl/threema-msgapi-sdk-python/compare/v3.1.0...v4.0.0
 .. _3.1.0: https://github.com/lgrahl/threema-msgapi-sdk-python/compare/v3.0.6...v3.1.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,16 @@
 Changelog
 *********
 
-`6.0.0`_ (TBD)
---------------
+.. `6.0.0`_ (TBD)
+.. ---------------------
 
-General:
+.. General:
 
-- Add support for Python 3.10
-- Drop support for Python versions below 3.7
+.. - Add support for Python 3.10
+.. - Drop support for Python versions below 3.7
+.. - Major dependencies bump to increase compatibility with other packages
+.. - Updated all tests to work with the newest dependencies
+
 
 `5.0.0`_ (2021-05-17)
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ imports (``isort``) and run the project's tests:
 .. code-block:: bash
 
     $ flake8 .
-    $ isort -rc .
+    $ isort .
     $ py.test
 
 You should also run the type checker that might catch some additional bugs:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,13 +1,13 @@
 Release Process
 ===============
 
-Signing key: https://lgrahl.de/pub/pgp-key.txt
+Signing key: <https://lgrahl.de/pub/pgp-key.txt>
 
 1. Check the code:
 
    ```bash
    flake8 .
-   isort -rc -c . || isort -rc -df
+   isort -c . || isort --df .
    mypy setup.py tests examples threema
    py.test
    ```
@@ -26,11 +26,11 @@ Signing key: https://lgrahl.de/pub/pgp-key.txt
 
 4. Do a signed commit and signed tag of the release:
 
-  ```bash
-  git add threema/gateway/__init__.py CHANGELOG.rst
-  git commit -S${GPG_KEY} -m "Release v${VERSION}"
-  git tag -u ${GPG_KEY} -m "Release v${VERSION}" v${VERSION}
-  ```
+   ```bash
+   git add threema/gateway/__init__.py CHANGELOG.rst
+   git commit -S${GPG_KEY} -m "Release v${VERSION}"
+   git tag -u ${GPG_KEY} -m "Release v${VERSION}" v${VERSION}
+   ```
 
 5. Build source and binary distributions:
 
@@ -69,4 +69,3 @@ Signing key: https://lgrahl.de/pub/pgp-key.txt
    ```
 
 10. Pat yourself on the back and celebrate!
-

--- a/examples/callback.py
+++ b/examples/callback.py
@@ -1,7 +1,6 @@
-import ssl
-
 import logbook
 import logbook.more
+import ssl
 from aiohttp import web
 
 from threema.gateway import (

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.10
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bdist_wheel]
-python-tag = py36.py37.py38.py39
+python-tag = py37.py38.py39.py310
 
 [flake8]
 max-line-length = 90

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,3 +14,6 @@ atomic = true
 include_trailing_comma = true
 known_standard_library = asyncio,typing
 known_first_party = threema
+
+[tool:pytest]
+asyncio_mode=strict

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,9 @@ if py_version < (3, 7, 0):
 # Note: These are just tools that aren't required, so a version range
 #       is not necessary here.
 tests_require = [
-    'pytest>=3.1.3,<4',
-    'pytest-asyncio>=0.6.0,<0.10',
-    'pytest-cov>=2.5.1,<3',
+    'pytest>=7.1..2,<8',
+    'pytest-asyncio>=0.18.3,<0.19',
+    'pytest-cov>=3.0.0,<4',
     'flake8==4.0.1',
     'isort==5.10.1',
     'collective.checkdocs>=0.2',
@@ -50,8 +50,7 @@ tests_require = [
 setup(
     name='threema.gateway',
     version=get_version(),
-    packages=find_packages(),
-    namespace_packages=['threema'],
+    packages=find_packages(include=["threema.*"]),
     install_requires=[
         'logbook>=1.1.0,<2',
         'libnacl>=1.5.2,<2',

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,11 @@ tests_require = [
     'pytest>=7.1..2,<8',
     'pytest-asyncio>=0.18.3,<0.19',
     'pytest-cov>=3.0.0,<4',
-    'flake8==4.0.1',
-    'isort==5.10.1',
-    'collective.checkdocs>=0.2',
-    'Pygments>=2.12.0',  # required by checkdocs
-    'mypy==0.961',
+    'flake8>=4.0.1,<5',
+    'isort>=5.10.1,<6',
+    'collective.checkdocs>=0.2,<1',
+    'Pygments>=2.12.0,<3',  # required by checkdocs
+    'mypy>=0.961<1',
 ]
 
 setup(
@@ -54,7 +54,7 @@ setup(
     install_requires=[
         'logbook>=1.5.3,<2',
         'libnacl>=1.8.0,<2',
-        'click>=6.7,<7',  # doesn't seem to follow semantic versioning
+        'click>=8.1.3,<9',  # doesn't seem to follow semantic versioning
         'aiohttp>=3.8.1,<4',
         'wrapt>=1.14.1,<2',
     ],

--- a/setup.py
+++ b/setup.py
@@ -52,16 +52,16 @@ setup(
     version=get_version(),
     packages=find_packages(include=["threema.*"]),
     install_requires=[
-        'logbook>=1.1.0,<2',
-        'libnacl>=1.5.2,<2',
+        'logbook>=1.5.3,<2',
+        'libnacl>=1.8.0,<2',
         'click>=6.7,<7',  # doesn't seem to follow semantic versioning
-        'aiohttp>=3.7.3,<4',
-        'wrapt>=1.10.10,<2',
+        'aiohttp>=3.8.1,<4',
+        'wrapt>=1.14.1,<2',
     ],
     tests_require=tests_require,
     extras_require={
         'dev': tests_require,
-        'uvloop': ['uvloop>=0.8.0,<2'],
+        'uvloop': ['uvloop>=0.16.0,<2'],
     },
     include_package_data=True,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import ast
 import os
 import sys
-
 from setuptools import (
     find_packages,
     setup,
@@ -41,11 +40,11 @@ tests_require = [
     'pytest>=3.1.3,<4',
     'pytest-asyncio>=0.6.0,<0.10',
     'pytest-cov>=2.5.1,<3',
-    'flake8==3.7.9',
-    'isort==4.3.21',
+    'flake8==4.0.1',
+    'isort==5.10.1',
     'collective.checkdocs>=0.2',
-    'Pygments>=2.2.0',  # required by checkdocs
-    'mypy==0.800',
+    'Pygments>=2.12.0',  # required by checkdocs
+    'mypy==0.961',
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,21 +1,21 @@
 import asyncio
 import asyncio.subprocess
+
+import aiohttp
 import binascii
 import collections
 import copy
 import hashlib
 import hmac
 import os
+import pytest
 import socket
 import ssl
 import subprocess
 import sys
 import time
-from contextlib import closing
-
-import aiohttp
-import pytest
 from aiohttp import web
+from contextlib import closing
 
 import threema.gateway
 from threema.gateway import e2e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,7 +62,8 @@ class Server:
         key = b'4a6a1b34dcef15d43cb74de2fd36091be99fbbaf126d099d47d83d919712c72b'
         self.echoecho_key = key
         self.echoecho_encoded_key = 'public:' + key.decode('ascii')
-        decoded_private_key = Key.decode(pytest.msgapi.private, Key.Type.private)
+        decoded_private_key = Key.decode(
+            pytest.msgapi['msgapi']['private'], Key.Type.private)
         self.mocking_key = Key.derive_public(decoded_private_key).hex_pk()
         self.blobs = {}
         self.latest_blob_ids = []
@@ -83,7 +84,7 @@ class Server:
     async def pubkeys(self, request):
         key = request.match_info['key']
         from_, secret = request.query['from'], request.query['secret']
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
         elif len(key) != 8:
             return web.Response(status=404)
@@ -96,7 +97,7 @@ class Server:
     async def lookup_phone(self, request):
         phone = request.match_info['phone']
         from_, secret = request.query['from'], request.query['secret']
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
         elif not phone.isdigit():
             return web.Response(status=404)
@@ -108,7 +109,7 @@ class Server:
         phone_hash = request.match_info['phone_hash']
         from_, secret = request.query['from'], request.query['secret']
         hash_ = '98b05f6eda7a878f6f016bdcdc9db6eb61a6b190e814ff787142115af144214c'
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
         elif len(phone_hash) % 2 != 0:
             # Note: This status code might not be intended and may change in the future
@@ -122,7 +123,7 @@ class Server:
     async def lookup_email(self, request):
         email = request.match_info['email']
         from_, secret = request.query['from'], request.query['secret']
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
         elif email == 'echoecho@example.com':
             return web.Response(body=b'ECHOECHO')
@@ -132,7 +133,7 @@ class Server:
         email_hash = request.match_info['email_hash']
         from_, secret = request.query['from'], request.query['secret']
         hash_ = '45a13d422b40f81936a9987245d3f6d9064c90607273af4f578246b4484669e2'
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
         elif len(email_hash) % 2 != 0:
             # Note: This status code might not be intended and may change in the future
@@ -146,7 +147,7 @@ class Server:
     async def capabilities(self, request):
         id_ = request.match_info['id']
         from_, secret = request.query['from'], request.query['secret']
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
         elif id_ == 'ECHOECHO':
             return web.Response(body=b'text,image,video,file')
@@ -156,7 +157,7 @@ class Server:
 
     async def credits(self, request):
         from_, secret = request.query['from'], request.query['secret']
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
         return web.Response(body=b'100')
 
@@ -164,7 +165,8 @@ class Server:
         post = await request.post()
 
         # Check API identity
-        if (post['from'], post['secret']) not in pytest.msgapi.api_identities:
+        if (post['from'], post['secret']) not in \
+                pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
 
         # Get ID from to, email or phone
@@ -179,7 +181,7 @@ class Server:
 
         # Process
         text = post['text']
-        if post['from'] == pytest.msgapi.nocredit_id:
+        if post['from'] == pytest.msgapi['msgapi']['nocredit_id']:
             return web.Response(status=402)
         elif id_ != 'ECHOECHO':
             return web.Response(status=400)
@@ -191,7 +193,8 @@ class Server:
         post = await request.post()
 
         # Check API identity
-        if (post['from'], post['secret']) not in pytest.msgapi.api_identities:
+        if (post['from'], post['secret']) not in \
+                pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
 
         # Get ID, nonce and box
@@ -199,7 +202,7 @@ class Server:
         nonce, box = binascii.unhexlify(post['nonce']), binascii.unhexlify(post['box'])
 
         # Process
-        if post['from'] == pytest.msgapi.nocredit_id:
+        if post['from'] == pytest.msgapi['msgapi']['nocredit_id']:
             return web.Response(status=402)
         elif id_ != 'ECHOECHO':
             return web.Response(status=400)
@@ -216,7 +219,7 @@ class Server:
 
             # Check API identity
             api_identity = (request.query['from'], request.query['secret'])
-            if api_identity not in pytest.msgapi.api_identities:
+            if api_identity not in pytest.values['msgapi']['api_identities']:
                 return web.Response(status=401)
         except KeyError:
             return web.Response(status=401)
@@ -232,7 +235,7 @@ class Server:
         blob_id = hashlib.sha256(blob).hexdigest()[:32]
 
         # Process
-        if request.query['from'] == pytest.msgapi.nocredit_id:
+        if request.query['from'] == pytest.msgapi['msgapi']['nocredit_id']:
             return web.Response(status=402)
         elif len(blob) == 0:
             return web.Response(status=400)
@@ -249,7 +252,7 @@ class Server:
 
         # Check API identity
         from_, secret = request.query['from'], request.query['secret']
-        if (from_, secret) not in pytest.msgapi.api_identities:
+        if (from_, secret) not in pytest.values['msgapi']['api_identities']:
             return web.Response(status=401)
 
         # Get blob
@@ -273,10 +276,19 @@ def pytest_report_header(config):
     return 'Using event loop: {}'.format(default_event_loop(config=config))
 
 
-def pytest_namespace():
+def values_plugin():
+    values = msgapi_plugin()
+    values['msgapi']['api_identities'] = {
+        (values['msgapi']['id'], values['msgapi']['secret']),
+        (values['msgapi']['nocredit_id'], values['msgapi']['secret'])
+    }
+    return values
+
+
+def msgapi_plugin():
     private = 'private:dd9413d597092b004fedc4895db978425efa328ba1f1ec6729e46e09231b8a7e'
     public = Key.encode(Key.derive_public(Key.decode(private, Key.Type.private)))
-    values = {'msgapi': {
+    msgapi = {'msgapi': {
         'cli_path': os.path.join(
             os.path.dirname(__file__),
             '../threema/gateway/bin/gateway_client.py',
@@ -291,11 +303,12 @@ def pytest_namespace():
         'nocredit_id': 'NOCREDIT',
         'noexist_id': '*NOEXIST',
     }}
-    values['msgapi']['api_identities'] = {
-        (values['msgapi']['id'], values['msgapi']['secret']),
-        (values['msgapi']['nocredit_id'], values['msgapi']['secret'])
-    }
-    return values
+    return msgapi
+
+
+def pytest_configure():
+    pytest.values = values_plugin()
+    pytest.msgapi = msgapi_plugin()
 
 
 def default_event_loop(request=None, config=None):
@@ -315,12 +328,12 @@ def unused_tcp_port():
     Find an unused localhost TCP port from 1024-65535 and return it.
     """
     with closing(socket.socket()) as sock:
-        sock.bind((pytest.msgapi.ip, 0))
+        sock.bind((pytest.msgapi['msgapi']['ip'], 0))
         return sock.getsockname()[1]
 
 
 def identity():
-    return pytest.msgapi.id, pytest.msgapi.secret
+    return pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret']
 
 
 @pytest.fixture(scope='module')
@@ -369,7 +382,9 @@ def api_server(request, event_loop, api_server_port, server):
         app.router.add_routes(server.routes)
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, host=pytest.msgapi.ip, port=port, shutdown_timeout=1.0)
+        site = web.TCPSite(
+            runner, host=pytest.msgapi['msgapi']['ip'], port=port, shutdown_timeout=1.0
+            )
         await site.start()
         return app, runner, site
     app, runner, site = event_loop.run_until_complete(start_server())
@@ -389,7 +404,7 @@ def mock_url(api_server_port):
     """
     Return the URL where the test server can be reached.
     """
-    return 'http://{}:{}'.format(pytest.msgapi.ip, api_server_port)
+    return 'http://{}:{}'.format(pytest.msgapi['msgapi']['ip'], api_server_port)
 
 
 @pytest.fixture(scope='module')
@@ -398,14 +413,14 @@ def connection(request, event_loop, api_server, mock_url):
         # Note: We're not doing anything with the server but obviously the
         # server needs to be started to be able to connect
         return threema.gateway.Connection(
-            identity=pytest.msgapi.id,
-            secret=pytest.msgapi.secret,
-            key=pytest.msgapi.private,
+            identity=pytest.msgapi['msgapi']['id'],
+            secret=pytest.msgapi['msgapi']['secret'],
+            key=pytest.msgapi['msgapi']['private'],
         )
     connection_ = event_loop.run_until_complete(create_connection())
 
     # Patch URLs
-    connection_.urls = {key: value.replace(pytest.msgapi.base_url, mock_url)
+    connection_.urls = {key: value.replace(pytest.msgapi['msgapi']['base_url'], mock_url)
                         for key, value in connection_.urls.items()}
 
     def fin():
@@ -421,15 +436,15 @@ def connection_blocking(request, event_loop, api_server, mock_url):
         # Note: We're not doing anything with the server but obviously the
         # server needs to be started to be able to connect
         return threema.gateway.Connection(
-            identity=pytest.msgapi.id,
-            secret=pytest.msgapi.secret,
-            key=pytest.msgapi.private,
+            identity=pytest.msgapi['msgapi']['id'],
+            secret=pytest.msgapi['msgapi']['secret'],
+            key=pytest.msgapi['msgapi']['private'],
             blocking=True,
         )
     connection_ = event_loop.run_until_complete(create_connection())
 
     # Patch URLs
-    connection_.urls = {key: value.replace(pytest.msgapi.base_url, mock_url)
+    connection_.urls = {key: value.replace(pytest.msgapi['msgapi']['base_url'], mock_url)
                         for key, value in connection_.urls.items()}
 
     def fin():
@@ -442,14 +457,14 @@ def connection_blocking(request, event_loop, api_server, mock_url):
 @pytest.fixture(scope='module')
 def invalid_connection(connection):
     invalid_connection_ = copy.copy(connection)
-    invalid_connection_.id = pytest.msgapi.noexist_id
+    invalid_connection_.id = pytest.msgapi['msgapi']['noexist_id']
     return invalid_connection_
 
 
 @pytest.fixture(scope='module')
 def nocredit_connection(connection):
     nocredit_connection_ = copy.copy(connection)
-    nocredit_connection_.id = pytest.msgapi.nocredit_id
+    nocredit_connection_.id = pytest.msgapi['msgapi']['nocredit_id']
     return nocredit_connection_
 
 
@@ -473,7 +488,7 @@ def cli(api_server, api_server_port, event_loop):
         test_api_mode = 'WARNING: Currently running in test mode!'
 
         # Call CLI in subprocess and get output
-        parameters = [sys.executable, pytest.msgapi.cli_path] + list(args)
+        parameters = [sys.executable, pytest.msgapi['msgapi']['cli_path']] + list(args)
         if isinstance(input, str):
             input = input.encode('utf-8')
 
@@ -529,14 +544,14 @@ def cli(api_server, api_server_port, event_loop):
 @pytest.fixture(scope='module')
 def private_key_file(tmpdir_factory):
     file = tmpdir_factory.mktemp('keys').join('private_key')
-    file.write(pytest.msgapi.private)
+    file.write(pytest.msgapi['msgapi']['private'])
     return str(file)
 
 
 @pytest.fixture(scope='module')
 def public_key_file(tmpdir_factory):
     file = tmpdir_factory.mktemp('keys').join('public_key')
-    file.write(pytest.msgapi.public)
+    file.write(pytest.msgapi['msgapi']['public'])
     return str(file)
 
 
@@ -568,11 +583,11 @@ def callback_server(request, event_loop, connection, callback, callback_server_p
         runner = web.AppRunner(app)
         await runner.setup()
 
-        cert_path = pytest.msgapi.cert_path
+        cert_path = pytest.msgapi['msgapi']['cert_path']
         ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
         ssl_context.load_cert_chain(certfile=cert_path)
         site = web.TCPSite(
-            runner, host=pytest.msgapi.ip, port=callback_server_port,
+            runner, host=pytest.msgapi['msgapi']['ip'], port=callback_server_port,
             ssl_context=ssl_context)
         await site.start()
 
@@ -632,7 +647,7 @@ def callback_send(callback_client, callback_server_port, connection):
 
         # Send message
         url = 'https://{}:{}/gateway_callback'.format(
-            pytest.msgapi.ip, callback_server_port)
+            pytest.msgapi['msgapi']['ip'], callback_server_port)
         return await callback_client.post(url, data=params)
 
     return send

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -8,7 +8,7 @@ class TestCallback:
     async def test_invalid_message(self, connection, callback_send, raw_message):
         outgoing = raw_message(
             connection=connection,
-            to_id=pytest.msgapi.id,
+            to_id=pytest.msgapi['msgapi']['id'],
             nonce=b'0' * 24,
             message=b'1' * 200
         )
@@ -20,7 +20,7 @@ class TestCallback:
     async def test_delivery_receipt(self, connection, callback_send, callback_receive):
         outgoing = e2e.DeliveryReceipt(
             connection=connection,
-            to_id=pytest.msgapi.id,
+            to_id=pytest.msgapi['msgapi']['id'],
             receipt_type=e2e.DeliveryReceipt.ReceiptType.read,
             message_ids=[b'0' * 8, b'1' * 8],
         )
@@ -36,7 +36,7 @@ class TestCallback:
     async def test_text_message(self, connection, callback_send, callback_receive):
         outgoing = e2e.TextMessage(
             connection,
-            to_id=pytest.msgapi.id,
+            to_id=pytest.msgapi['msgapi']['id'],
             text='私はガラスを食べられます。それは私を傷つけません。!',
         )
         response = await callback_send(outgoing)
@@ -52,7 +52,7 @@ class TestCallback:
     ):
         outgoing = e2e.ImageMessage(
             connection,
-            to_id=pytest.msgapi.id,
+            to_id=pytest.msgapi['msgapi']['id'],
             image_path=server.threema_jpg,
         )
         response = await callback_send(outgoing)
@@ -66,7 +66,7 @@ class TestCallback:
     async def test_video(self, connection, callback_send, callback_receive, server):
         outgoing = e2e.VideoMessage(
             connection,
-            to_id=pytest.msgapi.id,
+            to_id=pytest.msgapi['msgapi']['id'],
             duration=1,
             video_path=server.threema_mp4,
             thumbnail_path=server.threema_jpg,
@@ -86,7 +86,7 @@ class TestCallback:
     ):
         outgoing = e2e.FileMessage(
             connection,
-            to_id=pytest.msgapi.id,
+            to_id=pytest.msgapi['msgapi']['id'],
             file_path=server.threema_jpg,
         )
         response = await callback_send(outgoing)
@@ -102,7 +102,7 @@ class TestCallback:
     ):
         outgoing = e2e.FileMessage(
             connection,
-            to_id=pytest.msgapi.id,
+            to_id=pytest.msgapi['msgapi']['id'],
             file_path=server.threema_jpg,
             thumbnail_path=server.threema_jpg,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,17 +26,20 @@ class TestCLI:
         assert 'Invalid key format' in exc_info.value.output
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
-                'encrypt', pytest.msgapi.public, pytest.msgapi.private, input='meow')
+                'encrypt', pytest.msgapi['msgapi']['public'],
+                pytest.msgapi['msgapi']['private'], input='meow')
         assert 'Invalid key type' in exc_info.value.output
 
     @pytest.mark.asyncio
     async def test_encrypt_decrypt(self, cli):
         input = '私はガラスを食べられます。それは私を傷つけません。'
         output = await cli(
-            'encrypt', pytest.msgapi.private, pytest.msgapi.public, input=input)
+            'encrypt', pytest.msgapi['msgapi']['private'],
+            pytest.msgapi['msgapi']['public'], input=input)
         nonce, data = output.splitlines()
         output = await cli(
-            'decrypt', pytest.msgapi.private, pytest.msgapi.public, nonce, input=data)
+            'decrypt', pytest.msgapi['msgapi']['private'],
+            pytest.msgapi['msgapi']['public'], nonce, input=data)
         assert input in output
 
     @pytest.mark.asyncio
@@ -82,24 +85,26 @@ class TestCLI:
 
     @pytest.mark.asyncio
     async def test_derive(self, cli):
-        output = await cli('derive', pytest.msgapi.private)
-        assert pytest.msgapi.public in output
+        output = await cli('derive', pytest.msgapi['msgapi']['private'])
+        assert pytest.msgapi['msgapi']['public'] in output
 
     @pytest.mark.asyncio
     async def test_send_simple(self, cli):
-        id_, secret = pytest.msgapi.id, pytest.msgapi.secret
+        id_, secret = pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret']
         output = await cli('send_simple', 'ECHOECHO', id_, secret, input='Hello!')
         assert output
 
     @pytest.mark.asyncio
     async def test_send_e2e(self, cli, server):
         output_1 = await cli(
-            'send_e2e', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, input='Hello!')
+            'send_e2e', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            input='Hello!')
         assert output_1
         output_2 = await cli(
-            'send_e2e', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, '-k', server.echoecho_encoded_key, input='Hello!')
+            'send_e2e', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'], '-k',
+            server.echoecho_encoded_key, input='Hello!')
         assert output_2
         assert output_1 == output_2
 
@@ -107,13 +112,15 @@ class TestCLI:
     async def test_send_image(self, cli, server):
         server.latest_blob_ids = []
         output_1 = await cli(
-            'send_image', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_jpg)
+            'send_image', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_jpg)
         assert output_1
         assert len(server.latest_blob_ids) == 1
         output_2 = await cli(
-            'send_image', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_jpg, '-k', server.echoecho_encoded_key)
+            'send_image', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_jpg, '-k', server.echoecho_encoded_key)
         assert output_2
         assert output_1 == output_2
         assert len(server.latest_blob_ids) == 2
@@ -122,21 +129,22 @@ class TestCLI:
     async def test_send_video(self, cli, server):
         server.latest_blob_ids = []
         output_1 = await cli(
-            'send_video', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_mp4, server.threema_jpg)
+            'send_video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_mp4, server.threema_jpg)
         assert output_1
         assert len(server.latest_blob_ids) == 2
         output_2 = await cli(
-            'send_video', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_mp4, server.threema_jpg,
-            '-k', server.echoecho_encoded_key)
+            'send_video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_mp4, server.threema_jpg, '-k', server.echoecho_encoded_key)
         assert output_2
         assert output_1 == output_2
         assert len(server.latest_blob_ids) == 4
         output = await cli(
-            'send_video', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_mp4, server.threema_jpg,
-            '-d', '1337')
+            'send_video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_mp4, server.threema_jpg, '-d', '1337')
         assert output
         assert len(server.latest_blob_ids) == 6
 
@@ -144,66 +152,76 @@ class TestCLI:
     async def test_send_file(self, cli, server):
         server.latest_blob_ids = []
         output_1 = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_jpg)
+            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_jpg)
         assert output_1
         assert len(server.latest_blob_ids) == 1
         output_2 = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_jpg, '-k', server.echoecho_encoded_key)
+            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_jpg, '-k', server.echoecho_encoded_key)
         assert output_2
         assert output_1 == output_2
         assert len(server.latest_blob_ids) == 2
         output = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_jpg, '-t', server.threema_jpg)
+            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_jpg, '-t', server.threema_jpg)
         assert output
         assert len(server.latest_blob_ids) == 4
         output = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi.id, pytest.msgapi.secret,
-            pytest.msgapi.private, server.threema_jpg, '-k', server.echoecho_encoded_key,
-            '-t', server.threema_jpg)
+            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
+            server.threema_jpg, '-k', server.echoecho_encoded_key, '-t',
+            server.threema_jpg)
         assert output
         assert len(server.latest_blob_ids) == 6
 
     @pytest.mark.asyncio
     async def test_lookup_no_option(self, cli):
         with pytest.raises(subprocess.CalledProcessError):
-            await cli('lookup', pytest.msgapi.id, pytest.msgapi.secret)
+            await cli('lookup', pytest.msgapi['msgapi']['id'],
+                      pytest.msgapi['msgapi']['secret'])
 
     @pytest.mark.asyncio
     async def test_lookup_id_by_email(self, cli):
         output = await cli(
-            'lookup', pytest.msgapi.id, pytest.msgapi.secret,
+            'lookup', pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret'],
             '-e', 'echoecho@example.com')
         assert 'ECHOECHO' in output
         output = await cli(
-            'lookup', pytest.msgapi.id, pytest.msgapi.secret,
+            'lookup', pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret'],
             '--email', 'echoecho@example.com')
         assert 'ECHOECHO' in output
 
     @pytest.mark.asyncio
     async def test_lookup_id_by_phone(self, cli):
         output = await cli(
-            'lookup', pytest.msgapi.id, pytest.msgapi.secret, '-p', '44123456789')
+            'lookup', pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret'],
+            '-p', '44123456789')
         assert 'ECHOECHO' in output
         output = await cli(
-            'lookup', pytest.msgapi.id, pytest.msgapi.secret, '--phone', '44123456789')
+            'lookup', pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret'],
+            '--phone', '44123456789')
         assert 'ECHOECHO' in output
 
     @pytest.mark.asyncio
     async def test_lookup_pk_by_id(self, cli, server):
         output = await cli(
-            'lookup', pytest.msgapi.id, pytest.msgapi.secret, '-i', 'ECHOECHO')
+            'lookup', pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret'],
+            '-i', 'ECHOECHO')
         assert server.echoecho_encoded_key in output
         output = await cli(
-            'lookup', pytest.msgapi.id, pytest.msgapi.secret, '--id', 'ECHOECHO')
+            'lookup', pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret'],
+            '--id', 'ECHOECHO')
         assert server.echoecho_encoded_key in output
 
     @pytest.mark.asyncio
     async def test_capabilities(self, cli):
         output = await cli(
-            'capabilities', pytest.msgapi.id, pytest.msgapi.secret, 'ECHOECHO')
+            'capabilities', pytest.msgapi['msgapi']['id'],
+            pytest.msgapi['msgapi']['secret'], 'ECHOECHO')
         capabilities = {
             ReceptionCapability.text,
             ReceptionCapability.image,
@@ -214,22 +232,26 @@ class TestCLI:
 
     @pytest.mark.asyncio
     async def test_credits(self, cli):
-        output = await cli('credits', pytest.msgapi.id, pytest.msgapi.secret)
+        output = await cli('credits', pytest.msgapi['msgapi']['id'],
+                           pytest.msgapi['msgapi']['secret'])
         assert '100' in output
         output = await cli(
-            'credits', pytest.msgapi.nocredit_id, pytest.msgapi.secret)
+            'credits', pytest.msgapi['msgapi']['nocredit_id'],
+            pytest.msgapi['msgapi']['secret'])
         assert '0' in output
 
     @pytest.mark.asyncio
     async def test_invalid_id(self, cli):
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             await cli(
-                'credits', pytest.msgapi.noexist_id, pytest.msgapi.secret)
+                'credits', pytest.msgapi['msgapi']['noexist_id'],
+                pytest.msgapi['msgapi']['secret'])
         assert 'API identity or secret incorrect' in exc_info.value.output
 
     @pytest.mark.asyncio
     async def test_insufficient_credits(self, cli):
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
-            id_, secret = pytest.msgapi.nocredit_id, pytest.msgapi.secret
+            id_, secret = pytest.msgapi['msgapi']['nocredit_id'],\
+                pytest.msgapi['msgapi']['secret']
             await cli('send_simple', 'ECHOECHO', id_, secret, input='!')
         assert 'Insufficient credits' in exc_info.value.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
-import subprocess
-
 import pytest
+import subprocess
 
 from threema.gateway import ReceptionCapability
 from threema.gateway import __version__ as _version

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,18 +91,18 @@ class TestCLI:
     @pytest.mark.asyncio
     async def test_send_simple(self, cli):
         id_, secret = pytest.msgapi['msgapi']['id'], pytest.msgapi['msgapi']['secret']
-        output = await cli('send_simple', 'ECHOECHO', id_, secret, input='Hello!')
+        output = await cli('send-simple', 'ECHOECHO', id_, secret, input='Hello!')
         assert output
 
     @pytest.mark.asyncio
     async def test_send_e2e(self, cli, server):
         output_1 = await cli(
-            'send_e2e', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-e2e', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             input='Hello!')
         assert output_1
         output_2 = await cli(
-            'send_e2e', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-e2e', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'], '-k',
             server.echoecho_encoded_key, input='Hello!')
         assert output_2
@@ -112,13 +112,13 @@ class TestCLI:
     async def test_send_image(self, cli, server):
         server.latest_blob_ids = []
         output_1 = await cli(
-            'send_image', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-image', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_jpg)
         assert output_1
         assert len(server.latest_blob_ids) == 1
         output_2 = await cli(
-            'send_image', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-image', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_jpg, '-k', server.echoecho_encoded_key)
         assert output_2
@@ -129,20 +129,20 @@ class TestCLI:
     async def test_send_video(self, cli, server):
         server.latest_blob_ids = []
         output_1 = await cli(
-            'send_video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_mp4, server.threema_jpg)
         assert output_1
         assert len(server.latest_blob_ids) == 2
         output_2 = await cli(
-            'send_video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_mp4, server.threema_jpg, '-k', server.echoecho_encoded_key)
         assert output_2
         assert output_1 == output_2
         assert len(server.latest_blob_ids) == 4
         output = await cli(
-            'send_video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-video', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_mp4, server.threema_jpg, '-d', '1337')
         assert output
@@ -152,26 +152,26 @@ class TestCLI:
     async def test_send_file(self, cli, server):
         server.latest_blob_ids = []
         output_1 = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_jpg)
         assert output_1
         assert len(server.latest_blob_ids) == 1
         output_2 = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_jpg, '-k', server.echoecho_encoded_key)
         assert output_2
         assert output_1 == output_2
         assert len(server.latest_blob_ids) == 2
         output = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_jpg, '-t', server.threema_jpg)
         assert output
         assert len(server.latest_blob_ids) == 4
         output = await cli(
-            'send_file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
+            'send-file', 'ECHOECHO', pytest.msgapi['msgapi']['id'],
             pytest.msgapi['msgapi']['secret'], pytest.msgapi['msgapi']['private'],
             server.threema_jpg, '-k', server.echoecho_encoded_key, '-t',
             server.threema_jpg)
@@ -253,5 +253,5 @@ class TestCLI:
         with pytest.raises(subprocess.CalledProcessError) as exc_info:
             id_, secret = pytest.msgapi['msgapi']['nocredit_id'],\
                 pytest.msgapi['msgapi']['secret']
-            await cli('send_simple', 'ECHOECHO', id_, secret, input='!')
+            await cli('send-simple', 'ECHOECHO', id_, secret, input='!')
         assert 'Insufficient credits' in exc_info.value.output

--- a/threema/__init__.py
+++ b/threema/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)

--- a/threema/__init__.py
+++ b/threema/__init__.py
@@ -1,0 +1,1 @@
+__import__('pkg_resources').declare_namespace(__name__)

--- a/threema/gateway/__init__.py
+++ b/threema/gateway/__init__.py
@@ -30,7 +30,7 @@ from .exception import *  # noqa
 
 __author__ = 'Lennart Grahl <lennart.grahl@gmail.com>'
 __status__ = 'Production'
-__version__ = '5.0.0'
+__version__ = '6.0.0'
 feature_level = 3
 
 __all__ = tuple(itertools.chain(

--- a/threema/gateway/_gateway.py
+++ b/threema/gateway/_gateway.py
@@ -1,6 +1,5 @@
-import enum
-
 import aiohttp
+import enum
 import libnacl.encode
 import libnacl.public
 

--- a/threema/gateway/bin/gateway_client.py
+++ b/threema/gateway/bin/gateway_client.py
@@ -2,12 +2,11 @@
 The command line interface for the Threema gateway service.
 """
 import binascii
-import os
-import re
-
 import click
 import logbook
 import logbook.more
+import os
+import re
 
 from threema.gateway import Connection
 from threema.gateway import __version__ as _version

--- a/threema/gateway/e2e.py
+++ b/threema/gateway/e2e.py
@@ -1,6 +1,8 @@
 """
 Provides classes and functions for the end-to-end encryption mode.
 """
+from typing import Tuple
+
 import abc
 import binascii
 import collections
@@ -10,15 +12,13 @@ import functools
 import hashlib
 import hmac
 import json
-import mimetypes
-import os
-import struct
-from typing import Tuple
-
 import libnacl
 import libnacl.encode
 import libnacl.public
 import libnacl.secret
+import mimetypes
+import os
+import struct
 from aiohttp import web
 
 from . import ReceptionCapability

--- a/threema/gateway/key.py
+++ b/threema/gateway/key.py
@@ -4,7 +4,6 @@ Contains functions to decode, encode and generate keys.
 import enum
 import hashlib
 import hmac
-
 import libnacl.encode
 import libnacl.public
 import libnacl.secret

--- a/threema/gateway/util.py
+++ b/threema/gateway/util.py
@@ -2,25 +2,25 @@
 Utility functions.
 """
 import asyncio
+from typing import Set  # noqa
+
 import collections
 import functools
 import inspect
 import io
-import logging
-import os
-from typing import Set  # noqa
-
 import libnacl
 import logbook
 import logbook.compat
 import logbook.more
+import logging
+import os
 import wrapt
 
 from .key import Key
 from .memoization import (
-    make_key,
-    make_cache_value,
     is_cache_value_valid,
+    make_cache_value,
+    make_key,
     retrieve_result_from_cache_value,
 )
 


### PR DESCRIPTION
With this pull request, I bumped all the development dependencies. 
This caused some breakage with pytest. However, I replaced all the deprecated stuff and rewrote some things. All tests pass now with the newest dev dependencies and are compatible with Python 3.10.4. 
This should make future development a lot more easy and more in line with current standards. 

The project dependencies were also all bumped to the newest version. The only change needed was for click >7.0.0, but it was a straight forward fix to adopt new behaviour for versions 7 and up, [upgrading to 7.0 documentation](https://click.palletsprojects.com/en/8.1.x/upgrading/). 

I also fixed the quotes in the workflow file so the Python versions get treated as actual version numbers and not numbers which get standardized, e.g., Python 3.10 --> Python 3.1

I followed the standard procedure for releases. The code is formatted according to the repo standards, and merging with main is successful on my fork. 

Resolves #45 