### PR TITLE
Update e2e.py

### DIFF
--- a/threema/gateway/e2e.py
+++ b/threema/gateway/e2e.py
@@ -1297,7 +1297,7 @@ class FileMessage(Message):
     async def unpack(cls, connection, parameters, key_pair, reader):
         # Get payload
         try:
-            content = bytes(reader.readexactly(len(reader))).decode('ascii')
+            content = bytes(reader.readexactly(len(reader))).decode('utf-8')
         except UnicodeError as exc:
             raise MessageError('Could not decode JSON') from exc
 


### PR DESCRIPTION
Preventing UnicodeDecodeError in case that Umlaute, etc. are in e.g., an images description.

Original error-message read:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/threema/gateway/e2e.py", line 1300, in unpack
    content = bytes(reader.readexactly(len(reader))).decode('ascii')
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 259: ordinal not in range(128)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/python-docker/app.py", line 125, in handle_callback
    message = await e2e.Message.receive(connection, {
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/threema/gateway/e2e.py", line 506, in receive
    return await class_.unpack(connection, parameters, key_pair, reader)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/threema/gateway/e2e.py", line 1302, in unpack
    raise MessageError('Could not decode JSON') from exc
threema.gateway.exception.MessageError: Could not decode JSON