### PR TITLE
message_handler returns now the connection too 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ gen
 
 # MyPy Cache
 .mypy_cache/
+
+# macos
+.DS_Store

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -558,7 +558,7 @@ def callback(event_loop, connection):
     async def create_callback():
         queue = asyncio.Queue()
 
-        async def handle_message(message):
+        async def handle_message(message, conn):
             await queue.put(message)
 
         return Callback(queue, handle_message)

--- a/threema/gateway/e2e.py
+++ b/threema/gateway/e2e.py
@@ -221,7 +221,7 @@ async def handle_callback(context, request):
             raise CallbackError(400, str(exc)) from exc
 
         # Pass message to handler
-        await context.message_handler(message)
+        await context.message_handler(message, context.connection)
 
         # Respond with 'OK'
         return web.Response(status=200)


### PR DESCRIPTION
message_handler returns now the connection too and not only the message. That way after receiving a message, more messages can be sent back to the user as a reaction to that message or command. This should solve the issue #70.